### PR TITLE
Fix comparing number with table

### DIFF
--- a/QuestFrame.lua
+++ b/QuestFrame.lua
@@ -1206,7 +1206,9 @@ function Mod:Blizzard_WorldMap()
 	end
 	for _,of in ipairs(WorldMapFrame.overlayFrames) do
 		if of.OnLoad and of.OnLoad == WorldMapTrackingOptionsButtonMixin.OnLoad then
-			hooksecurefunc(of, "OnSelection", QuestMapFrame_UpdateAll)
+			hooksecurefunc(of, "OnSelection", function()
+				QuestMapFrame_UpdateAll()
+			end)
 		end
 	end
 end


### PR DESCRIPTION
`hooksecurefunc` passes the original parameters to the function defined as the hook, thus we need to prevent it from passing these to a function that does not expect them.

Fixes #34