### PR TITLE
Prevent crash with The War Within

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,11 +9,11 @@ jobs:
   package:
     runs-on: ubuntu-latest
     
-    env:
-      GITHUB_OAUTH: ${{ secrets.TOKEN_FOR_UPLOAD }}
-
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
-      - name: Packager
-        uses: BigWigsMods/packager@master
+
+      - name: Create Package
+        uses: BigWigsMods/packager@v2
+        env:
+          CF_API_KEY: ${{ secrets.CURSEFORGE_API_TOKEN }}

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,6 +1,8 @@
 package-as: AngrierWorldQuests
 
-manual-changelog: CHANGELOG.md
+manual-changelog:
+  filename: CHANGELOG.md
+  markup-type: markdown
 
 ignore:
 - CHANGELOG.md

--- a/AngrierWorldQuests.toc
+++ b/AngrierWorldQuests.toc
@@ -1,4 +1,4 @@
-## Interface: 100207
+## Interface: 110002
 ## Title: Angrier World Quests
 ## Notes: Adds World Quests to the quest list
 ## Author: GurliGebis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.42.9
+
+* Updated TOC to match WoW 11.0.2
+
 ## v0.42.8
 
 * Updated TOC to match WoW 10.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated TOC to match WoW 11.0.2
 * Updated github actions workflow for building the package.
+* Fixes needed so the addon doesn't crash. (Still not compatible with TWW, but it is being worked on)
 
 ## v0.42.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.42.9
 
 * Updated TOC to match WoW 11.0.2
+* Updated github actions workflow for building the package.
 
 ## v0.42.8
 

--- a/Config.lua
+++ b/Config.lua
@@ -458,7 +458,7 @@ function Config:CreatePanel()
 	panel.cancel = Panel_OnCancel
 	panel.default  = Panel_OnDefaults
 	panel.refresh  = Panel_OnRefresh
-	InterfaceOptions_AddCategory(panel)
+	Settings.RegisterCanvasLayoutCategory(panel, panel.name, panel.name)
 
 	return panel
 end
@@ -532,7 +532,6 @@ SLASH_ANGRIERWORLDQUESTS1 = "/awq"
 SLASH_ANGRIERWORLDQUESTS2 = "/angrierworldquests"
 function SlashCmdList.ANGRIERWORLDQUESTS(msg, editbox)
 	if optionPanel then
-		InterfaceOptionsFrame_OpenToCategory(optionPanel)
-		InterfaceOptionsFrame_OpenToCategory(optionPanel)
+		Settings.OpenToCategory(optionPanel.name)
 	end
 end


### PR DESCRIPTION
This is just to prevent the addon from crashing things.
Work is still being done on adding compatibility with TWW, but it will take some time, since the quest log has been changed quiet a bit.