### PR TITLE
Raise the width for TagText

### DIFF
--- a/Modules/QuestFrame/QuestFrameModule.lua
+++ b/Modules/QuestFrame/QuestFrameModule.lua
@@ -429,7 +429,7 @@ do
         button.TagText:SetJustifyH("RIGHT")
         button.TagText:SetTextColor(1, 1, 1)
         button.TagText:SetPoint("RIGHT", button.TagTexture, "LEFT", -2, 0)
-        button.TagText:SetWidth(28)
+        button.TagText:SetWidth(32)
         button.TagText:Hide()
 
         button.Text:ClearPoint("RIGHT")


### PR DESCRIPTION
Some font may wrap the itemlevel string
![1726061244451](https://github.com/user-attachments/assets/ac5304fb-3a10-424b-92ff-a4f7263d8e59)
