### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Hide World Quests header if the "hideQuestList" setting is set.
 * Hide the quest log background text if world quests are shown.
+* When searching the quest log, also search the World Quest list.
 
 ## 11.0.2-20241003-2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 11.0.2-20241008-1
 
 * Hide World Quests header if the "hideQuestList" setting is set.
+* Hide the quest log background text if world quests are shown.
 
 ## 11.0.2-20241003-2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.2-20241008-1
+
+* Hide World Quests header if the "hideQuestList" setting is set.
+
 ## 11.0.2-20241003-2
 
 * Added workaround for World Quest untracking causing taints.

--- a/Modules/QuestFrame/QuestFrameModule.lua
+++ b/Modules/QuestFrame/QuestFrameModule.lua
@@ -513,6 +513,18 @@ do
         return a.Text:GetText() < b.Text:GetText()
     end
 
+    function QuestFrameModule:HideWorldQuestsHeader()
+        for i = 1, #filterButtons do
+            filterButtons[i]:Hide()
+        end
+
+        if headerButton then
+            headerButton:Hide()
+        end
+
+        QuestScrollFrame.Contents:Layout()
+    end
+
     function QuestFrameModule:QuestLog_Update()
         titleFramePool:ReleaseAll()
 
@@ -522,20 +534,12 @@ do
 
         local tasksOnMap = C_TaskQuest.GetQuestsForPlayerByMapID(mapID)
         if (ConfigModule:Get("onlyCurrentZone")) and (not displayLocation or lockedQuestID) and not (tasksOnMap and #tasksOnMap > 0) and (mapID ~= MAPID_ARGUS) then
-            for i = 1, #filterButtons do
-                filterButtons[i]:Hide()
-            end
-
-            if headerButton then
-                headerButton:Hide()
-            end
-
-            QuestScrollFrame.Contents:Layout()
-
+            self:HideWorldQuestsHeader()
             return
         end
 
         if (ConfigModule:Get("hideQuestList")) then
+            self:HideWorldQuestsHeader()
             return
         end
 

--- a/Modules/QuestFrame/QuestFrameModule.lua
+++ b/Modules/QuestFrame/QuestFrameModule.lua
@@ -643,6 +643,8 @@ do
             local addedQuests = {}
             local displayMapIDs = DataModule:GetMapIDsToGetQuestsFrom(mapID)
 
+            local searchBoxText = QuestScrollFrame.SearchBox:GetText():lower()
+
             for mID in pairs(displayMapIDs) do
                 local taskInfo = C_TaskQuest.GetQuestsForPlayerByMapID(mID)
 
@@ -653,7 +655,7 @@ do
                                 local isFiltered = DataModule:IsQuestFiltered(info, mapID)
                                 if not isFiltered then
                                     if addedQuests[info.questId] == nil then
-                                        local button = QuestFrameModule:QuestLog_AddQuestButton(info)
+                                        local button = QuestFrameModule:QuestLog_AddQuestButton(info, searchBoxText)
 
                                         if button ~= nil then
                                             table.insert(usedButtons, button)
@@ -671,6 +673,9 @@ do
                 -- In the situation where the normal quest log is empty, but we have world quests.
                 -- We shouldn't show the empty quest log text.
                 QuestScrollFrame.EmptyText:Hide()
+
+                -- We need to also make sure the "No search results" text is hidden.
+                QuestScrollFrame.NoSearchResultsText:Hide()
             else
                 QuestFrameModule:HideWorldQuestsHeader()
                 return
@@ -698,7 +703,7 @@ do
         QuestScrollFrame.Contents:Layout()
     end
 
-    function QuestFrameModule:QuestLog_AddQuestButton(questInfo)
+    function QuestFrameModule:QuestLog_AddQuestButton(questInfo, searchBoxText)
         local questID = questInfo.questId
         local title, factionID, _ = C_TaskQuest.GetQuestInfoByQuestID(questID)
         local questTagInfo = C_QuestLog.GetQuestTagInfo(questID)
@@ -706,6 +711,10 @@ do
         C_TaskQuest.RequestPreloadRewardData(questID)
 
         if (questTagInfo == nil) then
+            return nil
+        end
+
+        if searchBoxText ~= "" and not title:lower():find(searchBoxText, 1, true) then
             return nil
         end
 

--- a/Modules/QuestFrame/QuestFrameModule.lua
+++ b/Modules/QuestFrame/QuestFrameModule.lua
@@ -667,6 +667,15 @@ do
                 end
             end
 
+            if #usedButtons > 0 then
+                -- In the situation where the normal quest log is empty, but we have world quests.
+                -- We shouldn't show the empty quest log text.
+                QuestScrollFrame.EmptyText:Hide()
+            else
+                QuestFrameModule:HideWorldQuestsHeader()
+                return
+            end
+
             table.sort(usedButtons, QuestSorter)
 
             for _, button in ipairs(usedButtons) do


### PR DESCRIPTION
* Hide World Quests header if the "hideQuestList" setting is set.
* Hide the quest log background text if world quests are shown.
* When searching the quest log, also search the World Quest list.