### PR TITLE
Don't hide the World Quests header if filters are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.0.5-20241030-1
+* Don't hide the World Quests header if filters are active.
+
 ## 11.0.5-20241023-1
 * C_TaskQuest.GetQuestsForPlayerByMapID has been changed to C_TaskQuest.GetQuestsOnMap.
 * Updated TOC to match WoW 11.0.5

--- a/Modules/QuestFrame/QuestFrameModule.lua
+++ b/Modules/QuestFrame/QuestFrameModule.lua
@@ -676,7 +676,8 @@ do
 
                 -- We need to also make sure the "No search results" text is hidden.
                 QuestScrollFrame.NoSearchResultsText:Hide()
-            else
+            elseif ConfigModule:HasFilters() == false then
+                -- We should only hide the header, if no filters are active.
                 QuestFrameModule:HideWorldQuestsHeader()
                 return
             end


### PR DESCRIPTION
This fixes #94