### PR TITLE
Sync map pin creation in WorkaroundsModule.lua with 11.0.7 original code

### DIFF
--- a/Modules/Workarounds/WorkaroundsModule.lua
+++ b/Modules/Workarounds/WorkaroundsModule.lua
@@ -50,7 +50,7 @@ local function WorkaroundMapTaints()
 
     function WorldMapFrame:AcquirePin(pinTemplate, ...)
         if not self.pinPools[pinTemplate] then
-            local pinTemplateType = self.pinTemplateTypes[pinTemplate] or "FRAME";
+            local pinTemplateType = self:GetPinTemplateType(pinTemplate);
             self.pinPools[pinTemplate] = CreateFramePool(pinTemplateType, self:GetCanvas(), pinTemplate, OnPinReleased);
         end
 


### PR DESCRIPTION
Original change by blizzard in 11.0.7: 
https://github.com/Gethe/wow-ui-source/compare/11.0.5..ptr#diff-46ab103dd7a2e33a4ff467531ff745c1d08cb4a19c0a03f298f4ff9cef1ad6a0L160-R208 (in case the link doesn't scroll correctly, its Blizzard_MapCanvas.lua)

This fixes lua errors when used together with Mapster